### PR TITLE
fix: explicitly define return type for recursive fibonacci function in fibs.ts

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-export default function fibonacci(n) {
+export default function fibonacci(n: number): number {
   if (n < 0) {
     return -1;
   } else if (n == 0) {


### PR DESCRIPTION
- Add explicit `number` return type to prevent union inference
- Ensure recursive calls resolve to numeric addition

I tested these changes by running several lint-tests in my local machine. Once they passed, I was reassured that the changes worked appropriately. Additionally, before making the changes, I ran the test-script that was previously made. All 10 tests passed, but the lint-tests failed. This meant the issues being resolved did not directly impact the program's final output, but were hidden issues that may cause future problems. Yet, this was just something I found interesting when doing the assignment. The testing procedure remained the same and I verified all lint-tests had passed.

Closed #10 #9 #8
